### PR TITLE
ARCでは動作しないメソッドの除去

### DIFF
--- a/unity/NativeDialogPlugin/Assets/Plugins/iOS/UNDialogManager.mm
+++ b/unity/NativeDialogPlugin/Assets/Plugins/iOS/UNDialogManager.mm
@@ -64,25 +64,14 @@ static UNDialogManager * shardDialogManager;
 
 - (id) init {
     alerts = [NSMutableDictionary dictionary];
-    [alerts retain];
-
     return [super init];
 }
 
-- (void) dealloc {
-    [decideLabel release];
-    [cancelLabel release];
-    [closeLabel release];
-    [alerts release];
-    [super dealloc];
-}
 
 - (int) showSelectDialog:(NSString *)msg {
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:nil message:msg delegate:self cancelButtonTitle:cancelLabel otherButtonTitles:decideLabel, nil];
     alert.tag = ++_id;
     [alert show];
-    [alert autorelease];
-    
     [alerts setObject:alert forKey:[NSNumber numberWithInt:_id]];
     return _id;
 }
@@ -91,8 +80,6 @@ static UNDialogManager * shardDialogManager;
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:msg delegate:self cancelButtonTitle:cancelLabel otherButtonTitles:decideLabel, nil];
     alert.tag = ++_id;
     [alert show];
-    [alert autorelease];
-    
     [alerts setObject:alert forKey:[NSNumber numberWithInt:_id]];
     return _id;
 }
@@ -101,8 +88,6 @@ static UNDialogManager * shardDialogManager;
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:nil message:msg delegate:self cancelButtonTitle:nil otherButtonTitles:closeLabel, nil];
     alert.tag = ++_id;
     [alert show];
-    [alert autorelease];
-    
     [alerts setObject:alert forKey:[NSNumber numberWithInt:_id]];
     return _id;
 }
@@ -111,8 +96,6 @@ static UNDialogManager * shardDialogManager;
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:msg delegate:self cancelButtonTitle:nil otherButtonTitles:closeLabel, nil];
     alert.tag = ++_id;
     [alert show];
-    [alert autorelease];
-    
     [alerts setObject:alert forKey:[NSNumber numberWithInt:_id]];
     return _id;
 }
@@ -124,17 +107,9 @@ static UNDialogManager * shardDialogManager;
 }
 
 - (void) setLabelTitleWithDecide:(NSString*)decide cancel:(NSString*)cancel close:(NSString*) close {
-    [decideLabel release];
-    [cancelLabel release];
-    [closeLabel release];
-
     decideLabel = [NSString stringWithString:decide];
     cancelLabel = [NSString stringWithString:cancel];
     closeLabel = [NSString stringWithString:close];
-    
-    [decideLabel retain];
-    [cancelLabel retain];
-    [closeLabel retain];
 }
 
 // delegate


### PR DESCRIPTION
こんにちは、便利なライブラリ公開されていてありがとうございます！


しかし、現在iOSでビルドしたらARC環境のためビルドできない状態になっておりまして、いくつかのメソッドを使わないようにしました。

もし過去の互換性も気になるようでしたら、別ブランチや別バイナリを用意しておくというのもで良いかもしれません。

Xcode12.4や実機でビルドできるのは確認しました。